### PR TITLE
switched to higher level string functions for extracting token

### DIFF
--- a/navigaid/access.go
+++ b/navigaid/access.go
@@ -91,15 +91,16 @@ func (err ErrNoToken) Error() string {
 }
 
 func getAuthToken(header http.Header) (string, error) {
-	bearerToken := header.Get("Authorization")
+	auth := header.Get("Authorization")
 
-	if !hasBearer(bearerToken) {
+	authType, token, _ := strings.Cut(auth, " ")
+	if token == "" {
 		return "", ErrNoToken{}
 	}
 
-	return bearerToken[7:], nil
-}
+	if strings.ToLower(authType) != "bearer" {
+		return "", ErrNoToken{}
+	}
 
-func hasBearer(authHeader string) bool {
-	return strings.HasPrefix(strings.ToLower(authHeader), "bearer")
+	return token, nil
 }

--- a/navigaid/access_internal_test.go
+++ b/navigaid/access_internal_test.go
@@ -1,0 +1,49 @@
+package navigaid
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestGetAuthToken(t *testing.T) {
+	samples := map[string]struct {
+		Input string
+		Token string
+		Fail  bool
+	}{
+		"OmittedToken": {Input: "Bearer ", Fail: true},
+		"OnlyBearer":   {Input: "Bearer", Fail: true},
+		"LowerBearer":  {Input: "bearer xxx", Token: "xxx"},
+		"UpperBearer":  {Input: "Bearer yyy", Token: "yyy"},
+		"MixyBearer":   {Input: "BeaReR zzz", Token: "zzz"},
+		"StrangeToken": {Input: "Bearer zzz./ foo", Token: "zzz./ foo"},
+		"NotBearer":    {Input: "Random token", Fail: true},
+	}
+
+	for name := range samples {
+		tc := samples[name]
+
+		t.Run(name, func(t *testing.T) {
+			header := make(http.Header)
+			header.Set("Authorization", tc.Input)
+
+			token, err := getAuthToken(header)
+			if err != nil {
+				if tc.Fail {
+					return
+				}
+
+				t.Fatalf("failed to parse input: %v", err)
+			}
+
+			if tc.Fail {
+				t.Fatalf("did not fail as expected")
+			}
+
+			if token != tc.Token {
+				t.Fatalf("wanted the token %q, got %q",
+					tc.Token, token)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The previous implementation panicked on the input "Bearer", and
returned a non-error result for "Bearer ". This implementation treats
both as ErrNoToken-cases.